### PR TITLE
chore: semaphore release_all can be a footgun

### DIFF
--- a/mea/src/condvar/mod.rs
+++ b/mea/src/condvar/mod.rs
@@ -97,7 +97,7 @@ impl Condvar {
 
     /// Wakes up all blocked tasks on this condvar.
     pub fn notify_all(&self) {
-        self.s.release_all();
+        self.s.notify_all();
     }
 
     /// Yields the current task until this condition variable receives a notification.

--- a/mea/src/internal/semaphore.rs
+++ b/mea/src/internal/semaphore.rs
@@ -113,8 +113,8 @@ impl Semaphore {
         }
     }
 
-    /// Adds many permits until there is no waiter.
-    pub(crate) fn release_all(&self) {
+    /// Adds as many permits until there is no waiter.
+    pub(crate) fn notify_all(&self) {
         let mut waiters = self.waiters.lock();
         let mut wakers = Vec::new();
         loop {

--- a/mea/src/semaphore/mod.rs
+++ b/mea/src/semaphore/mod.rs
@@ -169,15 +169,6 @@ impl Semaphore {
         self.s.release(permits);
     }
 
-    /// Adds many permits until all acquires are unblocked.
-    ///
-    /// This method is designed to work with the "acquire and forget" methods, where
-    /// acquires and releases are managed separately, rather than coupled with the drop
-    /// of [`SemaphorePermit`] or [`OwnedSemaphorePermit`].
-    pub fn release_all(&self) {
-        self.s.release_all();
-    }
-
     /// Attempts to acquire `n` permits from the semaphore without blocking.
     ///
     /// If the permits are successfully acquired, a [`SemaphorePermit`] is returned.


### PR DESCRIPTION
I try to use it as a mimic for tokio's semaphore.close, but notice that if we use an external atomicbool + release_all, there is a race condition between the check and release all waiter.

One should use Mutex + Condvar + inner counter + close state in such a scenario.

Or select acquire + latch (for close)