### PR TITLE
feat: add bounded mpsc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: Install toolchain
@@ -51,10 +52,12 @@ jobs:
   test:
     name: Run tests
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-22.04, macos-14, windows-2022 ]
         rust-version: [ "1.80.0", "stable" ]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2

--- a/mea/src/internal/semaphore.rs
+++ b/mea/src/internal/semaphore.rs
@@ -114,10 +114,18 @@ impl Semaphore {
         fut.await
     }
 
-    /// Adds `n` new permits to the semaphore.
+    /// Adds `n` permits to the semaphore.
     pub(crate) fn release(&self, n: usize) {
         if n != 0 {
             self.insert_permits_with_lock(n, self.waiters.lock());
+        }
+    }
+
+    /// Adds `n` permits to the semaphore if there is any waiter.
+    pub(crate) fn release_if_nonempty(&self, n: usize) {
+        let waiters = self.waiters.lock();
+        if !waiters.is_empty() {
+            self.insert_permits_with_lock(n, waiters);
         }
     }
 

--- a/mea/src/internal/semaphore.rs
+++ b/mea/src/internal/semaphore.rs
@@ -114,6 +114,16 @@ impl Semaphore {
         fut.await
     }
 
+    /// Returns a future that is resolved when acquired `n` permits from the semaphore.
+    pub(crate) fn poll_acquire(&self, n: usize) -> Acquire<'_> {
+        Acquire {
+            permits: n,
+            index: None,
+            semaphore: self,
+            done: false,
+        }
+    }
+
     /// Adds `n` permits to the semaphore.
     pub(crate) fn release(&self, n: usize) {
         if n != 0 {

--- a/mea/src/mpsc/bounded.rs
+++ b/mea/src/mpsc/bounded.rs
@@ -141,13 +141,9 @@ impl<T> BoundedSender<T> {
                     let poll = pin!(&mut self.acquire).poll(cx);
 
                     value = match self.sender.try_send(value) {
-                        Ok(()) => {
-                            self.sender.state.tx_permits.release_if_nonempty(1);
-                            return Poll::Ready(Ok(()));
-                        }
+                        Ok(()) => return Poll::Ready(Ok(())),
                         Err(TrySendError::Disconnected(value)) => {
-                            self.sender.state.tx_permits.notify_all();
-                            return Poll::Ready(Err(SendError::new(value)));
+                            return Poll::Ready(Err(SendError::new(value)))
                         }
                         Err(TrySendError::Full(value)) => value,
                     };

--- a/mea/src/mpsc/error.rs
+++ b/mea/src/mpsc/error.rs
@@ -21,7 +21,7 @@ use std::fmt;
 ///
 /// The message that could not be sent can be retrieved again with
 /// [`SendError::into_inner`].
-#[derive(PartialEq)]
+#[derive(Eq, PartialEq)]
 pub struct SendError<T>(T);
 
 impl<T> SendError<T> {
@@ -56,7 +56,7 @@ impl<T> fmt::Debug for SendError<T> {
 impl<T> std::error::Error for SendError<T> {}
 
 /// Error returned by `try_send`.
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(Eq, PartialEq)]
 pub enum TrySendError<T> {
     /// The channel is full, so data may not be sent at this time, but the receiver has not yet
     /// disconnected.

--- a/mea/src/mpsc/error.rs
+++ b/mea/src/mpsc/error.rs
@@ -79,16 +79,6 @@ impl<T> TrySendError<T> {
             TrySendError::Full(msg) | TrySendError::Disconnected(msg) => msg,
         }
     }
-
-    /// Creates a new `TrySendError::Full` with the given message.
-    pub(super) fn new_full(msg: T) -> TrySendError<T> {
-        TrySendError::Full(msg)
-    }
-
-    /// Creates a new `TrySendError::Disconnected` with the given message.
-    pub(super) fn new_disconnected(msg: T) -> TrySendError<T> {
-        TrySendError::Disconnected(msg)
-    }
 }
 
 impl<T> fmt::Display for TrySendError<T> {

--- a/mea/src/mpsc/mod.rs
+++ b/mea/src/mpsc/mod.rs
@@ -14,13 +14,18 @@
 
 //! A multi-producer, single-consumer queue for sending values between asynchronous tasks.
 
+mod bounded;
 mod error;
 #[cfg(test)]
 mod tests;
 mod unbounded;
 
+pub use bounded::bounded;
+pub use bounded::BoundedReceiver;
+pub use bounded::BoundedSender;
 pub use error::SendError;
 pub use error::TryRecvError;
+pub use error::TrySendError;
 pub use unbounded::unbounded;
 pub use unbounded::UnboundedReceiver;
 pub use unbounded::UnboundedSender;

--- a/mea/src/mpsc/tests.rs
+++ b/mea/src/mpsc/tests.rs
@@ -211,7 +211,7 @@ fn try_send_recv_bounded() {
             tx.try_send(i).unwrap();
         }
 
-        assert_eq!(tx.try_send(num), Err(TrySendError::new_full(num)));
+        assert_eq!(tx.try_send(num), Err(TrySendError::Full(num)));
 
         for i in 0..num {
             assert_eq!(rx.try_recv(), Ok(i));
@@ -221,6 +221,16 @@ fn try_send_recv_bounded() {
         drop(tx);
         assert_eq!(rx.try_recv(), Err(TryRecvError::Disconnected));
     }
+}
+
+#[tokio::test]
+async fn try_send_after_close_bounded() {
+    let (tx, rx) = mpsc::bounded(1);
+
+    tx.try_send(1).unwrap();
+    drop(rx);
+
+    assert_eq!(tx.try_send(3), Err(TrySendError::Disconnected(3)));
 }
 
 #[tokio::test]


### PR DESCRIPTION
As title.

A problem is that we use `self.state.tx_permits.release(u32::MAX as usize);` when droppint the `BoundedReceiver`, would this cause overflow when available permits are large?